### PR TITLE
various fixes

### DIFF
--- a/client/css/RelativeURLField.css
+++ b/client/css/RelativeURLField.css
@@ -21,6 +21,7 @@
 
 .field.relativeurl .input-group-append {
     z-index: 2;
+    flex: 0 0 auto;
 }
 
 .field.relativeurl .input-group-append:last-of-type {
@@ -50,6 +51,7 @@
 
 .field.relativeurl .edit-holder .BaseURL-link {
     margin-right: 6px;
+    flex: 0 0 auto;
 }
 
 .field.relativeurl .edit-holder .input-group {

--- a/src/Forms/RelativeURLField.php
+++ b/src/Forms/RelativeURLField.php
@@ -2,16 +2,13 @@
 
 namespace Fromholdio\RelativeURLField\Forms;
 
-use Fromholdio\ConfiguredMultisites\Multisites;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\Director;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Core\Manifest\ModuleLoader;
-use SilverStripe\Dev\Debug;
 use SilverStripe\Forms\ReadonlyField;
 use SilverStripe\Forms\TextField;
-use SilverStripe\ORM\DataObject;
 use SilverStripe\View\Parsers\URLSegmentFilter;
 use SilverStripe\View\Requirements;
 

--- a/src/Forms/RelativeURLField.php
+++ b/src/Forms/RelativeURLField.php
@@ -271,7 +271,8 @@ class RelativeURLField extends TextField
         $baseSiteTree = $this->getBaseSiteTree();
         $link = empty($baseSiteTree) ? $value : Controller::join_links($baseSiteTree->Link(), $value);
         $siteTree = SiteTree::get_by_link($link);
-        $hasCollision = !is_null($siteTree);
+        // check that link matches, because SiteTree::get_by_link() might return parent page + "action" if child page doesn't exist
+        $hasCollision = !is_null($siteTree) && $siteTree->Link() == $link;
         $this->extend('updateHasSiteTreeCollision', $hasCollision, $value);
         return $hasCollision;
     }

--- a/src/Forms/RelativeURLField.php
+++ b/src/Forms/RelativeURLField.php
@@ -2,12 +2,16 @@
 
 namespace Fromholdio\RelativeURLField\Forms;
 
+use Fromholdio\ConfiguredMultisites\Multisites;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\Director;
 use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Core\Manifest\ModuleLoader;
+use SilverStripe\Dev\Debug;
 use SilverStripe\Forms\ReadonlyField;
 use SilverStripe\Forms\TextField;
+use SilverStripe\ORM\DataObject;
 use SilverStripe\View\Parsers\URLSegmentFilter;
 use SilverStripe\View\Requirements;
 
@@ -34,7 +38,7 @@ class RelativeURLField extends TextField
         if (empty($value)) {
             return $this->httpError(
                 405,
-                _t(__CLASS__ .'.EMPTY', 'Please enter a URL or click cancel')
+                _t(__CLASS__ . '.EMPTY', 'Please enter a URL or click cancel')
             );
         }
 
@@ -110,8 +114,7 @@ class RelativeURLField extends TextField
                 $filteredParts[] = $filter->filter($valuePart);
             }
             $value = implode('/', $filteredParts);
-        }
-        else {
+        } else {
             $value = $filter->filter($value);
         }
 
@@ -270,13 +273,52 @@ class RelativeURLField extends TextField
         }
         $baseSiteTree = $this->getBaseSiteTree();
         $link = empty($baseSiteTree) ? $value : Controller::join_links($baseSiteTree->Link(), $value);
-        $siteTree = SiteTree::get_by_link($link);
-        // check that link matches, because SiteTree::get_by_link() might return parent page + "action" if child page doesn't exist
-        $hasCollision = !is_null($siteTree) && $siteTree->Link() == $link;
+
+        $rootID = ($multisitesClass = $this->getMultisitesClassName())
+            ? $multisitesClass::inst()->getCurrentSiteId()
+            : 0;
+
+        $parts = preg_split('|/+|', $link ?? '');
+        $URLSegment = array_shift($parts);
+        $siteTree = SiteTree::get()->filter([
+            'URLSegment' => $URLSegment,
+            'ParentID' => $rootID
+        ])->first();
+
+        if ($siteTree && SiteTree::config()->get('nested_urls') && count($parts ?? [])) {
+            foreach ($parts as $segment) {
+                $next = SiteTree::get()->filter([
+                    'URLSegment' => $segment,
+                    'ParentID' => $siteTree->ID
+                ])->first();
+
+                if (!$next) {
+                    break;
+                }
+
+                $siteTree->destroy();
+                $siteTree = $next;
+            }
+        }
+
+        // check that link matches, because SiteTree::get_by_link() might return parent page + "action"
+        $hasCollision = $siteTree && trim(Director::makeRelative($siteTree->Link()), '/') == trim($link, '/');
+
         $this->extend('updateHasSiteTreeCollision', $hasCollision, $value);
         return $hasCollision;
     }
 
+    public function getMultisitesClassName(): ?string
+    {
+        $manifest = ModuleLoader::inst()->getManifest();
+        if ($manifest->moduleExists('symbiote/silverstripe-multisites')) {
+            return \Symbiote\Multisites\Multisites::class;
+        }
+        if ($manifest->moduleExists('fromholdio/silverstripe-configured-multisites')) {
+            return \Fromholdio\ConfiguredMultisites\Multisites::class;
+        }
+        return null;
+    }
 
     public function Field($properties = [])
     {

--- a/templates/Fromholdio/RelativeURLField/Forms/RelativeURLField.ss
+++ b/templates/Fromholdio/RelativeURLField/Forms/RelativeURLField.ss
@@ -17,12 +17,12 @@
         <div class="input-group">
             <input $AttributesHTML />
             <div class="input-group-append">
-                <button role="button" data-icon="accept" type="button" class="btn btn-primary update">
+                <button role="button" type="button" class="btn btn-primary font-icon-tick update">
                     <%t SilverStripe\CMS\Forms\SiteTreeURLSegmentField.OK 'OK' %>
                 </button>
             </div>
             <div class="input-group-append">
-                <button role="button" data-icon="cancel" type="button" class="btn btn-outline-secondary btn-sm input-group-append cancel">
+                <button role="button" type="button" class="btn btn-outline-secondary btn-sm font-icon-cancel input-group-append cancel">
                     <%t SilverStripe\CMS\Forms\SiteTreeURLSegmentField.Cancel 'Cancel' %>
                 </button>
             </div>


### PR DESCRIPTION
fix icons and styles as well as an endless loop if `SiteTree::get_by_link()` in the collision check returns the parent page of a created redirect. 

e.g. `SiteTree::get_by_link('existing/non-existing')` returns the 'existing' page and treats the 'non-existing' part as an action. The module assumes that in this case `SiteTree::get_by_link()` would return null, but that's not the case.